### PR TITLE
fixes #6820 - apipie-bindings should enforce required params, BZ 1116803

### DIFF
--- a/lib/apipie_bindings/action.rb
+++ b/lib/apipie_bindings/action.rb
@@ -1,3 +1,5 @@
+require 'apipie_bindings/utilities'
+
 module ApipieBindings
 
   class Action
@@ -56,16 +58,34 @@ module ApipieBindings
     end
 
     def validate!(params)
-      # return unless params.is_a?(Hash)
+      missing_params = missing_params(api_params_tree { |par| par.required? }, params_tree(params))
+      raise ApipieBindings::MissingArgumentsError.new(missing_params) unless missing_params.empty?
+    end
 
-      # invalid_keys = params.keys.map(&:to_s) - (rules.is_a?(Hash) ? rules.keys : rules)
-      # raise ArgumentError, "Invalid keys: #{invalid_keys.join(", ")}" unless invalid_keys.empty?
+    def api_params_tree(&block)
+      ApipieBindings::Utilities.params_hash_tree(self.params, &block)
+    end
 
-      # if rules.is_a? Hash
-      #   rules.each do |key, sub_keys|
-      #     validate_params!(params[key], sub_keys) if params[key]
-      #   end
-      # end
+    def params_tree(params)
+      params.inject([]) do |tree, (key, val)|
+        subtree = val.is_a?(Hash) ? { key.to_s => params_tree(val) } : key.to_s
+        tree << subtree
+        tree
+      end
+    end
+
+    def missing_params(master, slave)
+      missing = []
+      master.each do |required_param|
+        if required_param.is_a?(Hash)
+          key = required_param.keys.first
+          slave_hash = slave.select { |p| p.is_a?(Hash) && p[key] }
+          missing << missing_params(required_param[key], slave_hash.first ? slave_hash.first[key] : [])
+        else
+          missing << required_param unless slave.include?(required_param)
+        end
+      end
+      missing.flatten.sort
     end
 
     def to_s

--- a/lib/apipie_bindings/api.rb
+++ b/lib/apipie_bindings/api.rb
@@ -145,7 +145,7 @@ module ApipieBindings
       resource = resource(resource_name)
       action = resource.action(action_name)
       route = action.find_route(params)
-      #action.validate(params)
+      action.validate!(params)
       options[:fake_response] = find_match(fake_responses, resource_name, action_name, params) || action.examples.first if dry_run?
       return http_call(
         route.method,

--- a/lib/apipie_bindings/exceptions.rb
+++ b/lib/apipie_bindings/exceptions.rb
@@ -3,4 +3,13 @@ module ApipieBindings
   class ConfigurationError < StandardError; end
   class DocLoadingError < StandardError; end
 
+  class MissingArgumentsError < StandardError
+    attr_reader :params
+
+    def initialize(params)
+      @params = params
+    end
+
+  end
+
 end

--- a/lib/apipie_bindings/param.rb
+++ b/lib/apipie_bindings/param.rb
@@ -1,3 +1,5 @@
+require 'apipie_bindings/utilities'
+
 module ApipieBindings
 
   class Param
@@ -11,8 +13,12 @@ module ApipieBindings
       @params = params.map { |p| ApipieBindings::Param.new(p) }
       @expected_type = param[:expected_type].to_sym
       @description = param[:description].gsub(/<\/?[^>]+?>/, "")
-      @required = param[:required]
+      @required = param[:required] || @params.inject(false) { |req, par| req ||= par.required? }
       @validator = param[:validator]
+    end
+
+    def tree(&block)
+      ApipieBindings::Utilities.params_hash_tree(@params, &block)
     end
 
     def required?

--- a/lib/apipie_bindings/utilities.rb
+++ b/lib/apipie_bindings/utilities.rb
@@ -1,0 +1,18 @@
+module ApipieBindings
+
+  module Utilities
+
+    def self.params_hash_tree(params_hash, &block)
+      block ||= lambda { |_| true }
+      params_hash.inject([]) do |tree, par|
+        if block.call(par)
+          subtree = par.expected_type == :hash ? { par.name => par.tree(&block) } : par.name
+          tree << subtree
+        end
+        tree
+      end
+    end
+
+  end
+
+end

--- a/test/unit/action_test.rb
+++ b/test/unit/action_test.rb
@@ -41,8 +41,20 @@ describe ApipieBindings::Action do
     # incuded params in alphanumeric order.
 
 
-  it "should validate the params" do
-    resource.action(:create).validate!({ :architecture => { :name => 'i386' } })
+  it "should validate incorrect params" do
+    proc do
+      resource.action(:create).validate!({ :architecture => { :foo => "foo" } })
+    end.must_raise(ApipieBindings::MissingArgumentsError)
+
+    proc do
+      # completely different sub-hash; should still fail
+      resource.action(:create).validate!({ :organization => { :name => "acme" } })
+    end.must_raise(ApipieBindings::MissingArgumentsError)
+  end
+
+  it "should accept correct params" do
+    resource.action(:create).validate!({:architecture => { :name => 'i386' } })
+    resource.action(:create_unnested).validate!(:name => "i386")
   end
 
   it "should have name visible in puts" do

--- a/test/unit/data/architecture.json
+++ b/test/unit/data/architecture.json
@@ -145,6 +145,44 @@
                             }
                         ],
                         "see": []
+                    },
+                    {
+                        "apis": [
+                            {
+                                "api_url": "/api/architectures",
+                                "http_method": "POST",
+                                "short_description": "create an architecture."
+                            }
+                        ],
+                        "doc_url": "/apidoc/v2/architectures/create",
+                        "errors": [],
+                        "examples" : [
+                            "same as nested create"
+                        ],
+                        "formats": null,
+                        "full_description": "",
+                        "name": "create_unnested",
+                        "params":[
+                            {
+                                "allow_nil": false,
+                                "description": "",
+                                "expected_type": "string",
+                                "full_name": "architecture[name]",
+                                "name": "name",
+                                "required": true,
+                                "validator": "Must be String"
+                            },
+                            {
+                                "allow_nil": false,
+                                "description": "\n<p>Operatingsystem ID\u2019s</p>\n",
+                                "expected_type": "array",
+                                "full_name": "architecture[operatingsystem_ids]",
+                                "name": "operatingsystem_ids",
+                                "required": false,
+                                "validator": "Must be Array"
+                            }
+                        ],
+                        "see": []
                     }
                 ]
             }

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -6,7 +6,7 @@ describe ApipieBindings::Resource do
     :apidoc_cache_name => 'architecture'}).resource(:architectures) }
 
   it "should list actions" do
-    resource.actions.map(&:name).must_equal [:index, :show, :create]
+    resource.actions.map(&:name).must_equal [:index, :show, :create, :create_unnested]
   end
 
   it "should test action existence" do


### PR DESCRIPTION
- [x] validate presense of params (nested and un-nested)
- [x] do not rely on `gettext`
- [x] refactor `Param#tree` and `Action#tree` into one? ([discussion](https://github.com/Apipie/apipie-bindings/pull/12#discussion-diff-15759442))
- [x] write a deep diff for `Hash` ([discussion](https://github.com/Apipie/apipie-bindings/pull/12#discussion-diff-15758740))
- [x] tests!
- [x] squash commits once tests are green
