### PR TITLE
Add apidoc_cache_base_dir option to move all caches to another dir

### DIFF
--- a/lib/apipie_bindings/api.rb
+++ b/lib/apipie_bindings/api.rb
@@ -24,7 +24,9 @@ module ApipieBindings
     # @option config [Hash] :headers additional headers to send with the requests
     # @option config [String] :api_version ('1') version of the API
     # @option config [String] :language prefered locale for the API description
-    # @option config [String] :apidoc_cache_dir ('~/.cache/apipie_bindings/<URI>') where
+    # @option config [String] :apidoc_cache_base_dir ('~/.cache/apipie_bindings') base
+    #   directory for building apidoc_cache_dir
+    # @option config [String] :apidoc_cache_dir (apidoc_cache_base_dir+'/<URI>') where
     #   to cache the JSON description of the API
     # @option config [String] :apidoc_cache_name ('default.json') name of te cache file.
     #   If there is cache in the :apidoc_cache_dir, it is used.
@@ -53,7 +55,8 @@ module ApipieBindings
       @uri = config[:uri]
       @api_version = config[:api_version] || 1
       @language = config[:language]
-      @apidoc_cache_dir = config[:apidoc_cache_dir] || File.join(File.expand_path('~/.cache'), 'apipie_bindings', @uri.tr(':/', '_'))
+      apidoc_cache_base_dir = config[:apidoc_cache_base_dir] || File.join(File.expand_path('~/.cache'), 'apipie_bindings')
+      @apidoc_cache_dir = config[:apidoc_cache_dir] || File.join(apidoc_cache_base_dir, @uri.tr(':/', '_'))
       @apidoc_cache_name = config[:apidoc_cache_name] || set_default_name
       @dry_run = config[:dry_run] || false
       @aggressive_cache_checking = config[:aggressive_cache_checking] || false

--- a/test/unit/api_test.rb
+++ b/test/unit/api_test.rb
@@ -140,6 +140,13 @@ describe ApipieBindings::API do
     it "should complain when no uri or cache dir is set" do
       proc {ApipieBindings::API.new({})}.must_raise ApipieBindings::ConfigurationError
     end
+
+    it "should obey :apidoc_cache_base_dir to generate apidoc_cache_dir" do
+      Dir.mktmpdir do |dir|
+        api = ApipieBindings::API.new({:uri => 'http://example.com', :apidoc_cache_base_dir => dir})
+        api.apidoc_cache_file.must_equal File.join(dir, 'http___example.com', 'default.json')
+      end
+    end
   end
 
 end


### PR DESCRIPTION
This is to fix http://projects.theforeman.org/issues/7063, which means we can't expand $HOME in the context of a Puppet run (it's unset usually for daemons).  This will allow us to reconfigure it to one of Puppet's own cache directories.
