### PR TITLE
Change license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,20 @@
-This program and entire repository is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+Copyright 2014 Martin Bačovský and contributors
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ TODO
 License
 -------
 
-This project is licensed under the GPLv3+.
+This project is licensed under the MIT license.

--- a/apipie-bindings.gemspec
+++ b/apipie-bindings.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors       = ["Martin Bačovský"]
   s.email         = "mbacovsk@redhat.com"
   s.homepage      = "http://github.com/Apipie/apipie-bindings"
-  s.license       = "GPL-3"
+  s.license       = "MIT"
 
   s.summary       = %q{The Ruby bindings for Apipie documented APIs}
   s.description   = <<EOF


### PR DESCRIPTION
Due to some requests to loosen the licensing on this lib, to make it easier to use for other projects, I'd like to suggest change to MIT license. If I understand the process correctly we can do that if all the contributors agree. Therefore I'd like to ask @tstrachota, @domcleal and @komidore64 for ACK or NAK.

DO NOT MERGE before the packaging for RPMs and DEBs is finished
