### PR TITLE
Fixes #7408 - added lazy loading of credentials

### DIFF
--- a/lib/apipie_bindings.rb
+++ b/lib/apipie_bindings.rb
@@ -1,4 +1,5 @@
 require 'apipie_bindings/version'
+require 'apipie_bindings/credentials'
 require 'apipie_bindings/exceptions'
 require 'apipie_bindings/inflector'
 require 'apipie_bindings/indifferent_hash'

--- a/lib/apipie_bindings/credentials.rb
+++ b/lib/apipie_bindings/credentials.rb
@@ -1,0 +1,22 @@
+module ApipieBindings
+
+  # AbstractCredentials class can hold your logic to get
+  # users credentials. It defines interface that can be used
+  # by ApipieBindings when the credentials are needed to create connection
+  class AbstractCredentials
+
+    # Convert credentials to hash usable for merging to RestClient configuration
+    # @return [Hash]
+    def to_params
+      {}
+    end
+
+    # Check that credentials storage is empty
+    def empty?
+    end
+
+    # Clear credentials storage
+    def clear
+    end
+  end
+end


### PR DESCRIPTION
- credentials container with prompt ability
- support API documentation (JSON) accessible without authentication
- RestClient connection initialized only when needed
- option to to use unauthenticated connection for method calls
