### PR TITLE
Allow newer gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.1
+  - ruby-head
   - jruby-18mode
   - jruby-19mode
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.1
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source "http://rubygems.org"
 gemspec
 
 if RUBY_VERSION < "1.9"
-gem 'rest-client', '< 1.7'
-gem 'mime-types', '~> 1.0'
+  gem 'rest-client', '< 1.7'
+  gem 'mime-types', '~> 1.0'
 end
 
 # load local gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,11 @@ source "http://rubygems.org"
 
 gemspec
 
+if RUBY_VERSION < "1.9"
+gem 'rest-client', '< 1.7'
+gem 'mime-types', '~> 1.0'
+end
+
 # load local gemfile
 local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')
 self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)

--- a/apipie-bindings.gemspec
+++ b/apipie-bindings.gemspec
@@ -24,10 +24,9 @@ EOF
   s.require_paths    = ["lib"]
 
   s.add_dependency 'json', '>= 1.2.1'
-  s.add_dependency 'rest-client', '>= 1.6.5', '< 1.7' # lower versions don't allow setting infinite timeouts, higher versions are not ruby 1.8 compatible
+  s.add_dependency 'rest-client', '>= 1.6.5', '< 3.0' # lower versions don't allow setting infinite timeouts
   s.add_dependency 'oauth'
   s.add_dependency 'awesome_print'
-  s.add_dependency 'mime-types', '~> 1.0'  #newer versions of mime-types are not 1.8 compatible
 
   s.add_development_dependency 'rake', '~> 10.1.0'
   s.add_development_dependency 'thor'
@@ -37,4 +36,5 @@ EOF
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'ci_reporter', '>= 1.6.3', "< 2.0.0"
 
+  s.required_ruby_version = '>= 1.8.7'
 end


### PR DESCRIPTION
Now that ruby 1.9.3 is EOL'd, do you still need to peg the gems to 1.8?
Not suggesting to make any changes that are not 1.8 friendly, but just allowing newer gems.

IPv6 support has been added to more recent versions of rest-client.
We came over from `foreman_api` which has a more lax dependency on `rest-client`, allowing us able to use the version of `rest-client` that we need.

e.g.:

```
gem "apipie-bindings", "~> 0.0.11" 
gem "rest-client", "1.7.1"
gem "mime-types", "~> 1.0"
```

I temporarily added `jruby` to travis to see how this change in `Gemfile` affects it as well.

If this breaks the 1.8 build, will need to go back and see how that works.