### PR TITLE
Fixes #27 - support rest-client 1.8.0

### DIFF
--- a/apipie-bindings.gemspec
+++ b/apipie-bindings.gemspec
@@ -24,8 +24,7 @@ EOF
   s.require_paths    = ["lib"]
 
   s.add_dependency 'json', '>= 1.2.1'
-  s.add_dependency 'rest-client', '>= 1.6.5', '< 1.8.0' # lower versions don't allow setting infinite timeouts
-                                                        # higher versions changed params in Response object:x
+  s.add_dependency 'rest-client', '>= 1.6.5'      # lower versions don't allow setting infinite timeouts
   s.add_dependency 'oauth'
   s.add_dependency 'awesome_print'
 

--- a/test/unit/api_test.rb
+++ b/test/unit/api_test.rb
@@ -159,7 +159,12 @@ describe ApipieBindings::API do
     let(:fake_empty_response) {
       data = ApipieBindings::Example.new('', '', '', 200, '[]')
       net_http_resp = Net::HTTPResponse.new(1.0, data.status, "")
-      RestClient::Response.create(data.response, net_http_resp, {})
+      if RestClient::Response.method(:create).arity == 4 # RestClient >= 1.8.0
+        RestClient::Response.create(data.response, net_http_resp, {},
+          RestClient::Request.new(:method=>'GET', :url=>'http://example.com'))
+      else
+        RestClient::Response.create(data.response, net_http_resp, {})
+      end
     }
 
     it "should call credentials to_param when :credentials are set and doing authenticated call" do


### PR DESCRIPTION
Adds support for rest-client 1.8.0. `verify_ssl` was set to false explicitly to preserve the behaviour. It can be overwritten with bindings argument..