### PR TITLE
Fixes #29 - make awesome_print optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ irb> api.resource(:architectures).action(:show).call(:id => 1)
 
 ```
 
+#### Logging
+It is possible to set custom (`Logger` compatible) logger while creating API instance.
+
+```ruby
+ApipieBindings::API.new({:uri => 'http://localhost:3000/', :logger => Logging.logger(STDOUT)})
+```
+
+Add gem `awesome_print` to your application Gemfile if you want to debug api calls with awesome inspect.
+
 Documentation
 -------------
 there is not much of the library documented yet, but we started to document our API with Yard.
@@ -77,7 +86,6 @@ The docs are installed with the gem and can be viewed from the docs dir directly
 
 TODO
 ----
-* parameter validation
 * update docs
 
 

--- a/apipie-bindings.gemspec
+++ b/apipie-bindings.gemspec
@@ -26,7 +26,6 @@ EOF
   s.add_dependency 'json', '>= 1.2.1'
   s.add_dependency 'rest-client', '>= 1.6.5'      # lower versions don't allow setting infinite timeouts
   s.add_dependency 'oauth'
-  s.add_dependency 'awesome_print'
 
   s.add_development_dependency 'rake', '~> 10.1.0'
   s.add_development_dependency 'thor'

--- a/lib/apipie_bindings.rb
+++ b/lib/apipie_bindings.rb
@@ -1,4 +1,5 @@
 require 'apipie_bindings/version'
+require 'apipie_bindings/utils'
 require 'apipie_bindings/credentials'
 require 'apipie_bindings/exceptions'
 require 'apipie_bindings/inflector'

--- a/lib/apipie_bindings/api.rb
+++ b/lib/apipie_bindings/api.rb
@@ -1,7 +1,6 @@
 require 'json'
 require 'rest_client'
 require 'oauth'
-require 'awesome_print'
 require 'apipie_bindings/rest_client_oauth'
 require 'logger'
 require 'tmpdir'
@@ -85,7 +84,7 @@ module ApipieBindings
       headers.merge!(config[:headers]) unless config[:headers].nil?
       headers.merge!(options.delete(:headers)) unless options[:headers].nil?
 
-      log.debug "Global headers: #{headers.ai}"
+      log.debug "Global headers: #{inspect_data(headers)}"
 
       @credentials = config[:credentials] if config[:credentials] && config[:credentials].respond_to?(:to_params)
 
@@ -194,8 +193,8 @@ module ApipieBindings
       end
 
       log.info "#{http_method.to_s.upcase} #{path}"
-      log.debug "Params: #{params.ai}"
-      log.debug "Headers: #{headers.ai}"
+      log.debug "Params: #{inspect_data(params)}"
+      log.debug "Headers: #{inspect_data(headers)}"
 
       args << headers if headers
 
@@ -218,14 +217,14 @@ module ApipieBindings
           update_cache(response.headers[:apipie_checksum])
         rescue => e
           log.debug e.message + "\n" +
-            (e.respond_to?(:response) ? process_data(e.response).ai : e.ai)
+            inspect_data(e.respond_to?(:response) ? process_data(e.response) : e)
           raise
         end
       end
 
       result = options[:response] == :raw ? response : process_data(response)
-      log.debug "Response: %s" % (options[:reduce_response_log] ? "Received OK" : result.ai)
-      log.debug "Response headers: #{response.headers.ai}" if response.respond_to?(:headers)
+      log.debug "Response: %s" % (options[:reduce_response_log] ? "Received OK" : inspect_data(result))
+      log.debug "Response headers: #{inspect_data(response.headers)}" if response.respond_to?(:headers)
       result
     end
 
@@ -345,6 +344,9 @@ module ApipieBindings
              end
       return data
     end
-  end
 
+    def inspect_data(obj)
+      ApipieBindings::Utils.inspect_data(obj)
+    end
+  end
 end

--- a/lib/apipie_bindings/utils.rb
+++ b/lib/apipie_bindings/utils.rb
@@ -1,0 +1,7 @@
+module ApipieBindings
+  module Utils
+    def self.inspect_data(obj)
+      obj.respond_to?(:ai) ? obj.ai : obj.inspect
+    end
+  end
+end


### PR DESCRIPTION
Logging use awesome_print to inspect data only if it is available.