### PR TITLE
Enable for mocking api calls with validations

### DIFF
--- a/lib/apipie_bindings/action.rb
+++ b/lib/apipie_bindings/action.rb
@@ -2,7 +2,7 @@ module ApipieBindings
 
   class Action
 
-    attr_reader :name
+    attr_reader :name, :resource
 
     def initialize(resource, name, api)
       @resource = resource
@@ -57,7 +57,7 @@ module ApipieBindings
 
     def validate!(parameters)
       errors = validate(params, parameters)
-      
+
       missing_arguments, errors = errors.partition { |e| e.kind == :missing_argument }
       missing_arguments.map! { |e| e.argument }
       raise ApipieBindings::MissingArgumentsError.new(missing_arguments) unless missing_arguments.empty?
@@ -65,7 +65,7 @@ module ApipieBindings
       invalid_types, errors = errors.partition { |e| e.kind == :invalid_type }
       invalid_types.map! { |e| [e.argument, e.details] }
       raise ApipieBindings::InvalidArgumentTypesError.new(invalid_types) unless invalid_types.empty?
-      
+
       errors.map! { |e| e.argument }
       raise ApipieBindings::ValidationError.new(errors) unless errors.empty?
     end
@@ -82,7 +82,7 @@ module ApipieBindings
       values.each do |param, value|
         param_description = params.find { |p| p.name == param.to_s }
         if param_description
-        
+
           # nested?
           if !param_description.params.empty? && !value.nil?
             # array

--- a/lib/apipie_bindings/api.rb
+++ b/lib/apipie_bindings/api.rb
@@ -159,9 +159,14 @@ module ApipieBindings
       check_cache if @aggressive_cache_checking
       resource = resource(resource_name)
       action = resource.action(action_name)
-      route = action.find_route(params)
       action.validate!(params) unless options[:skip_validation]
       options[:fake_response] = find_match(fake_responses, resource_name, action_name, params) || action.examples.first if dry_run?
+
+      call_action(action, params, headers, options)
+    end
+
+    def call_action(action, params={}, headers={}, options={})
+      route = action.find_route(params)
       return http_call(
         route.method,
         route.path(params),


### PR DESCRIPTION
Wrapping http_call with one more layer to enable for mocking and setting
expectations on api calls while keeping param validations in place.