### PR TITLE
Don't try to clear credentials if nil.

### DIFF
--- a/lib/apipie_bindings/api.rb
+++ b/lib/apipie_bindings/api.rb
@@ -115,7 +115,7 @@ module ApipieBindings
 
     def clear_credentials
       @client_with_auth = nil
-      @credentials.clear
+      @credentials.clear if @credentials
     end
 
     def apidoc


### PR DESCRIPTION
The instance variable `credentials` can be nil if not passed during
construction, causing a NoMethodError on any subsequent http call
that returns unauthorized.