### PR TITLE
Support rest-client 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,25 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.2.2
 #  - ruby-head
-  - jruby-18mode
   - jruby-19mode
 # - jruby-head
+env:
+  - REST_CLIENT_VERSION=1.6.0
+  - REST_CLIENT_VERSION=1.7.0
+  - REST_CLIENT_VERSION=1.8.0
+  - REST_CLIENT_VERSION=2.0.0.rc4
+matrix:
+  include:
+    - rvm: 1.8.7
+      env: REST_CLIENT_VERSION=1.6.0
+    - rvm: jruby-18mode
+      env: REST_CLIENT_VERSION=1.6.0
+  exclude:
+    - rvm: 1.9.3
+      env: REST_CLIENT_VERSION=2.0.0.rc4
+    - rvm: jruby-19mode
+      env: REST_CLIENT_VERSION=2.0.0.rc4

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,18 @@ source "http://rubygems.org"
 
 gemspec
 
+rest_client = if ENV.key?('REST_CLIENT_VERSION')
+                ["~> #{ENV['REST_CLIENT_VERSION']}"]
+              else
+                ['< 3.0']
+              end
+
 if RUBY_VERSION < "1.9"
-  gem 'rest-client', '< 1.7'
+  rest_client << '< 1.7'
   gem 'mime-types', '~> 1.0'
 end
+
+gem 'rest-client', rest_client
 
 # load local gemfile
 local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')

--- a/apipie-bindings.gemspec
+++ b/apipie-bindings.gemspec
@@ -24,7 +24,7 @@ EOF
   s.require_paths    = ["lib"]
 
   s.add_dependency 'json', '>= 1.2.1'
-  s.add_dependency 'rest-client', '>= 1.6.5', '< 2.0.0'      # lower versions don't allow setting infinite timeouts, higher versions have different api
+  s.add_dependency 'rest-client', '>= 1.6.5', '< 3.0.0'      # lower versions don't allow setting infinite timeouts, higher versions have different api
   s.add_dependency 'oauth'
 
   s.add_development_dependency 'rake', '~> 10.1.0'


### PR DESCRIPTION
Removes two arguments from Response.return! that are no longer supplied
on 2.x. Also fixes the arguments passed when creating fake
request/response objects for tests, allowing testing on all supported
versions of rest-client.