### PR TITLE
Avoid exception in http_call rescue block

### DIFF
--- a/lib/apipie_bindings/api.rb
+++ b/lib/apipie_bindings/api.rb
@@ -223,8 +223,8 @@ module ApipieBindings
           update_cache(response.headers[:apipie_checksum])
         rescue => e
           clear_credentials if e.is_a? RestClient::Unauthorized
-          log.debug e.message + "\n" +
-            inspect_data(e.respond_to?(:response) ? process_data(e.response) : e)
+          log.error e.message
+          log.debug inspect_data(e)
           raise
         end
       end
@@ -385,7 +385,10 @@ module ApipieBindings
     end
 
     def inspect_data(obj)
-      ApipieBindings::Utils.inspect_data(obj)
+      ApipieBindings::Utils.inspect_data(obj.respond_to?(:response) ? process_data(obj.response) : obj)
+    rescue => e
+      log.debug "Error during inspecting response: #{e.message}"
+      ''
     end
 
     def create_fake_response(status, body, method, path, args=[])


### PR DESCRIPTION
From Satellite 6.2 upgrade incident:

```
[ERROR 2016-07-25 08:52:01 main]  /Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[ec-satellite.cc.cec.eu.int]: Could   +not evaluate: undefined method `closed?' for nil:NilClass
[ INFO 2016-07-25 08:52:01 main] /usr/share/ruby/net/http/response.rb:325:in `stream_check'
[ INFO 2016-07-25 08:52:01 main] /usr/share/ruby/net/http/response.rb:199:in `read_body'
[ INFO 2016-07-25 08:52:01 main] /usr/share/ruby/net/http/response.rb:226:in `body'
[ INFO 2016-07-25 08:52:01 main] /usr/share/gems/gems/apipie-bindings-0.0.11/lib/apipie_bindings/api.rb:335:in `process_data'  [ INFO 2016-07-25 08:52:01 main] /usr/share/gems/gems/apipie-bindings-0.0.11/lib/apipie_bindings/api.rb:214:in `rescue in      +http_call'
[ INFO 2016-07-25 08:52:01 main] /usr/share/gems/gems/apipie-bindings-0.0.11/lib/apipie_bindings/api.rb:206:in `http_call'
[ INFO 2016-07-25 08:52:01 main] /usr/share/gems/gems/apipie-bindings-0.0.11/lib/apipie_bindings/api.rb:160:in `call'
[ INFO 2016-07-25 08:52:01 main] /usr/share/gems/gems/apipie-bindings-0.0.11/lib/apipie_bindings/resource.rb:14:in `call'
[ INFO 2016-07-25 08:52:01 main] /usr/share/katello-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest_v2.  +rb:31:in `proxy' 
[ INFO 2016-07-25 08:52:01 main] /usr/share/katello-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest_v2.  +rb:36:in `id'
[ INFO 2016-07-25 08:52:01 main] /usr/share/katello-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest_v2.  +rb:40:in `exists?'
[ INFO 2016-07-25 08:52:01 main] /usr/share/ruby/vendor_ruby/puppet/property/ensure.rb:81:in `retrieve'
```

It looks like there was an exception while trying to dump extra information from the response in the rescue block, but apparently there is no body (stream was not created), therefore this fails and new exception hides the root cause. This fixes it so we can see the root cause (e.g. authentication issue, firewall misconfiguration or something else).