### PR TITLE
Pin rest-client to proper version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 
 if RUBY_VERSION < "2.0"
   gem 'json', '< 2.0.0'
+  rest_client << '< 2.0.0'
 end
 
 gem 'rest-client', rest_client


### PR DESCRIPTION
Having `rest-client < 3.0.0` when latest rest-client is 2.0.0 makes no sense and also breaks on 1.9.3