### PR TITLE
legacy auth supports username config key

### DIFF
--- a/lib/apipie_bindings/api.rb
+++ b/lib/apipie_bindings/api.rb
@@ -296,8 +296,8 @@ module ApipieBindings
     private
 
     def legacy_authenticator(config)
-      if config[:user] || config[:password]
-        Authenticators::BasicAuth.new(config[:user], config[:password])
+      if config[:user] || config[:username] || config[:password]
+        Authenticators::BasicAuth.new(config[:user] || config[:username], config[:password])
       elsif config[:credentials] && config[:credentials].respond_to?(:to_params)
         log.warn("Credentials are now deprecated, use custom authenticator instead.")
         Authenticators::CredentialsLegacy.new(config[:credentials])


### PR DESCRIPTION
This is a fix for a regression added in 0.0.19 which inhibits a user from logging in to the API after an upgrade.

In 0.0.18 the username had to be specified in a hash with the key `username` for basic auth. 0.0.19 now expects `user`.