### PR TITLE
Fixes #58 - Verify SSL by default

### DIFF
--- a/lib/apipie_bindings/api.rb
+++ b/lib/apipie_bindings/api.rb
@@ -101,7 +101,7 @@ module ApipieBindings
       @resource_config = {
         :timeout  => config[:timeout],
         :headers  => headers,
-        :verify_ssl => false  # keep rest_client >= 1.8.0 setup comaptible
+        :verify_ssl => true
       }.merge(options)
 
       @config = config


### PR DESCRIPTION
SSL is turned on by default in RestClient >= 1.7.
ApipieBindings kept this off for compatibility reasons.
It is time to enforce the security a bit.