### PR TITLE
Remove error log output from specs

### DIFF
--- a/test/unit/api_test.rb
+++ b/test/unit/api_test.rb
@@ -229,7 +229,8 @@ describe ApipieBindings::API do
         :uri => 'http://example.com',
         :api_version => 2,
         :apidoc_cache_base_dir => cache_dir,
-        :authenticator => authenticator
+        :authenticator => authenticator,
+        :logger => Logger.new(File::NULL)
       }
       base_params.merge(params)
     end
@@ -371,7 +372,10 @@ describe ApipieBindings::API do
     it "should call clear_credentials when doing authenticated call and auth error is raised" do
       Dir.mktmpdir do |dir|
         credentials = ApipieBindings::AbstractCredentials.new
-        api = ApipieBindings::API.new({:uri => 'http://example.com', :apidoc_cache_base_dir => dir, :api_version => 2,
+        api = ApipieBindings::API.new({:uri => 'http://example.com',
+                                       :logger => Logger.new(File::NULL),
+                                       :apidoc_cache_base_dir => dir,
+                                       :api_version => 2,
                                        :credentials => credentials})
         credentials.expects(:clear)
         api.stubs(:call_client).raises(RestClient::Unauthorized)


### PR DESCRIPTION
Sets the `:logger` to `Logger.new(File::NULL)` for relevant tests, which dumps the output to `/dev/null` (or equivalent on host platform).

This makes the output from test runner much easier to parse, and doesn't make a good run look like there are failures.

**BEFORE**

    $ bundle exec rake
    Run options: --seed 53981

    # Running tests:

    ...............E, [2018-11-28T19:24:36.212945 #44993] ERROR -- : Unauthorized
    ..E, [2018-11-28T19:24:36.214864 #44993] ERROR -- : Unauthorized
    ..E, [2018-11-28T19:24:36.216317 #44993] ERROR -- : ApipieBindings::AuthenticatorMissingError
    .E, [2018-11-28T19:24:36.217075 #44993] ERROR -- : Unauthorized
    ......E, [2018-11-28T19:24:36.222096 #44993] ERROR -- : Unauthorized
    ................................................................

    Finished tests in 0.062298s, 1444.6692 tests/s, 1878.0699 assertions/s.

    90 tests, 117 assertions, 0 failures, 0 errors, 0 skips

**AFTER**

    $ bundle exec rake
    Run options: --seed 58893

    # Running tests:

    ..........................................................................................

    Finished tests in 0.074339s, 1210.6700 tests/s, 1573.8711 assertions/s.

    90 tests, 117 assertions, 0 failures, 0 errors, 0 skips


I currently tried to target this to just the offending specs, but this could easily be done in a more global fashion in the `test_helper.rb` (maybe...).

I believe this was introduced in https://github.com/Apipie/apipie-bindings/pull/48 since the default logger is set to stderr on the `Logger::ERROR`, and the existing specs that triggered an error (just `RestClient::Unauthorized` at the time) would end up producing a log message.