### PR TITLE
Set also open and read timeouts

### DIFF
--- a/lib/apipie_bindings/api.rb
+++ b/lib/apipie_bindings/api.rb
@@ -42,7 +42,7 @@ module ApipieBindings
     #   if the local cache of API description (JSON) is up to date. By default it is checked
     #   *after* each API request
     # @option config [Object] :logger (Logger.new(STDERR)) custom logger class
-    # @option config [Number] :timeout API request timeout in seconds, use -1 to disable timeout
+    # @option config [Number] :timeout API request, open and read timeout in seconds, use -1 to disable timeout
     # @option config [Symbol] :follow_redirects (:default) Possible values are :always, :never and :default.
     #   The :default is to only redirect in GET and HEAD requests (RestClient default)
     # @option config [AbstractAuthenticator] :authenticator API request authenticator
@@ -111,6 +111,8 @@ module ApipieBindings
 
       @resource_config = {
         :timeout  => config[:timeout],
+        :read_timeout  => config[:timeout],
+        :open_timeout  => config[:timeout],
         :headers  => headers,
         :verify_ssl => true
       }.merge(options)


### PR DESCRIPTION
Multiple users hit an issue when Foreman does block the request for longer period of time until it quits:

```
RestClient::Exceptions::ReadTimeout (Timed out reading data from server):
    /opt/theforeman/tfm/root/usr/share/gems/gems/rest-client-2.0.2/lib/restclient/request.rb:733:in `rescue in transmit'
    /opt/theforeman/tfm/root/usr/share/gems/gems/rest-client-2.0.2/lib/restclient/request.rb:642:in `transmit'
    /opt/theforeman/tfm/root/usr/share/gems/gems/rest-client-2.0.2/lib/restclient/request.rb:145:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/rest-client-2.0.2/lib/restclient/request.rb:52:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/rest-client-2.0.2/lib/restclient/resource.rb:67:in `post'
    /opt/theforeman/tfm/root/usr/share/gems/gems/apipie-bindings-0.3.0/lib/apipie_bindings/api.rb:327:in `call_client'
    /opt/theforeman/tfm/root/usr/share/gems/gems/apipie-bindings-0.3.0/lib/apipie_bindings/api.rb:240:in `http_call'
    /opt/theforeman/tfm/root/usr/share/gems/gems/apipie-bindings-0.3.0/lib/apipie_bindings/api.rb:190:in `call_action'
    /opt/theforeman/tfm/root/usr/share/gems/gems/apipie-bindings-0.3.0/lib/apipie_bindings/api.rb:185:in `call'
    /opt/theforeman/tfm/root/usr/share/gems/gems/apipie-bindings-0.3.0/lib/apipie_bindings/resource.rb:21:in `call'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.19.2.1/lib/hammer_cli/apipie/command.rb:53:in `send_request'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_foreman-0.19.6.5/lib/hammer_cli_foreman/commands.rb:188:in `send_request'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.19.2.1/lib/hammer_cli/apipie/command.rb:34:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.19.2.1/lib/hammer_cli/abstract.rb:76:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.19.2.1/lib/hammer_cli/abstract.rb:76:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.19.2.1/lib/hammer_cli/abstract.rb:76:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.1.2/lib/clamp/command.rb:132:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.19.2.1/bin/hammer:147:in `<top (required)>'
    /bin/hammer:23:in `load'
    /bin/hammer:23:in `<main>'
```