### PR TITLE
Add support for kerberos negotiate auth

### DIFF
--- a/apipie-bindings.gemspec
+++ b/apipie-bindings.gemspec
@@ -25,6 +25,7 @@ EOF
   s.add_dependency 'json', '>= 1.2.1'
   s.add_dependency 'rest-client', '>= 1.6.5', '< 3.0.0'      # lower versions don't allow setting infinite timeouts, higher versions have different api
   s.add_dependency 'oauth'
+  s.add_dependency 'gssapi'
   s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'thor'
   s.add_development_dependency 'minitest', '4.7.4'

--- a/lib/apipie_bindings/authenticators.rb
+++ b/lib/apipie_bindings/authenticators.rb
@@ -1,4 +1,5 @@
 require 'apipie_bindings/authenticators/basic_auth'
 require 'apipie_bindings/authenticators/credentials_legacy'
 require 'apipie_bindings/authenticators/oauth'
+require 'apipie_bindings/authenticators/negotiate'
 require 'apipie_bindings/authenticators/token_auth'

--- a/lib/apipie_bindings/authenticators/base.rb
+++ b/lib/apipie_bindings/authenticators/base.rb
@@ -1,6 +1,13 @@
 module ApipieBindings
   module Authenticators
     class Base
+      # In case an authenticator needs to make an authentication call
+      # before the original one you might want to set auth_cookie
+      # returned by the server to be available for futher processing
+      # (e.g. saving the session id) since it may contain session id
+      # to use with all the next calls
+      attr_reader :auth_cookie
+
       def authenticate(request, args)
       end
 

--- a/lib/apipie_bindings/authenticators/negotiate.rb
+++ b/lib/apipie_bindings/authenticators/negotiate.rb
@@ -32,6 +32,10 @@ module ApipieBindings
         headers = { 'Authorization' => "Negotiate #{Base64.strict_encode64(token)}" }
 
         RestClient::Request.execute(@auth_request_options.merge(headers: headers, url: @authorization_url)) do |response, request, raw_response|
+          if response.code == 401
+            raise RestClient::Unauthorized.new(response), 'Negotiation authentication did not pass.'
+          end
+
           # This part is only for next calls, that could be simplified if all resources are behind negotiate auth
           itok = Array(raw_response['WWW-Authenticate']).pop.split(/\s+/).last
           @gsscli.init_context(Base64.strict_decode64(itok)) # The context should now return true

--- a/lib/apipie_bindings/authenticators/negotiate.rb
+++ b/lib/apipie_bindings/authenticators/negotiate.rb
@@ -1,4 +1,5 @@
 require 'apipie_bindings/authenticators/base'
+require 'gssapi'
 
 module ApipieBindings
   module Authenticators
@@ -34,7 +35,6 @@ module ApipieBindings
       end
 
       def authenticate(original_request, args)
-        require 'gssapi'
         uri = URI.parse(@authorization_url)
         @gsscli = GSSAPI::Simple.new(uri.host, @service)
 

--- a/lib/apipie_bindings/authenticators/negotiate.rb
+++ b/lib/apipie_bindings/authenticators/negotiate.rb
@@ -45,8 +45,7 @@ module ApipieBindings
           if response.code == 401
             raise RestClient::Unauthorized.new(response), 'Negotiation authentication did not pass.'
           end
-
-          if response.code == 302
+          if response.code == 302 && response.headers[:location].end_with?('/users/login')
             raise ApipieBindings::ConfigurationError, 'Server misconfiguration detected'
           end
 

--- a/lib/apipie_bindings/authenticators/negotiate.rb
+++ b/lib/apipie_bindings/authenticators/negotiate.rb
@@ -37,6 +37,7 @@ module ApipieBindings
           @gsscli.init_context(Base64.strict_decode64(itok)) # The context should now return true
 
           cookie = raw_response['set-cookie'].split('; ')[0]
+          @auth_cookie = cookie
           original_request['Cookie'] = cookie
         end
 

--- a/lib/apipie_bindings/authenticators/negotiate.rb
+++ b/lib/apipie_bindings/authenticators/negotiate.rb
@@ -36,6 +36,8 @@ module ApipieBindings
             raise RestClient::Unauthorized.new(response), 'Negotiation authentication did not pass.'
           end
 
+          raise ApipieBindings::AuthenticatorError.new(:negotiate, e) if response.code == 302
+
           # This part is only for next calls, that could be simplified if all resources are behind negotiate auth
           itok = Array(raw_response['WWW-Authenticate']).pop.split(/\s+/).last
           @gsscli.init_context(Base64.strict_decode64(itok)) # The context should now return true

--- a/lib/apipie_bindings/authenticators/negotiate.rb
+++ b/lib/apipie_bindings/authenticators/negotiate.rb
@@ -41,6 +41,8 @@ module ApipieBindings
         end
 
         original_request
+      rescue GSSAPI::GssApiError => e
+        raise ApipieBindings::AuthenticatorError.new(:negotiate, e)
       end
     end
   end

--- a/lib/apipie_bindings/authenticators/negotiate.rb
+++ b/lib/apipie_bindings/authenticators/negotiate.rb
@@ -1,0 +1,47 @@
+require 'apipie_bindings/authenticators/base'
+
+module ApipieBindings
+  module Authenticators
+    # Negotiate authenticator
+    # Implements gssapi negotiation with preexisting kerberos ticket
+    # Requires a authentication url, the authentication request will be against.
+    # This url needs to support auth negotiation and after successful auth it should return 'set-cookie' header with session.
+    # This session will be initiated in the auth request and the original request will be made with this cookie.
+    # Next requests should be already skip the negotiation, please implement Session support in your client, for not using the negotiation on every request.
+    class Negotiate < Base
+
+      # Creates new authenticator for Negotiate auth
+      # @param [String] url to make authentication request to.
+      # @param [Hash] auth_request_options passed to RestClient::Request - especially for SSL options
+      #   see https://github.com/rest-client/rest-client/blob/master/lib/restclient/request.rb.
+      # @option service service principal used for gssapi tickets - defaults to HTTP.
+      # @option method http method used for the auth request - defaults to 'get'.
+      def initialize(authorization_url, auth_request_options = {})
+        @authorization_url = authorization_url
+        @service = auth_request_options.delete(:service) || 'HTTP'
+        auth_request_options[:method] ||= 'get'
+        @auth_request_options = auth_request_options
+      end
+
+      def authenticate(original_request, args)
+        require 'gssapi'
+        uri = URI.parse(@authorization_url)
+        @gsscli = GSSAPI::Simple.new(uri.host, @service)
+
+        token = @gsscli.init_context
+        headers = { 'Authorization' => "Negotiate #{Base64.strict_encode64(token)}" }
+
+        RestClient::Request.execute(@auth_request_options.merge(headers: headers, url: @authorization_url)) do |response, request, raw_response|
+          # This part is only for next calls, that could be simplified if all resources are behind negotiate auth
+          itok = Array(raw_response['WWW-Authenticate']).pop.split(/\s+/).last
+          @gsscli.init_context(Base64.strict_decode64(itok)) # The context should now return true
+
+          cookie = raw_response['set-cookie'].split('; ')[0]
+          original_request['Cookie'] = cookie
+        end
+
+        original_request
+      end
+    end
+  end
+end

--- a/lib/apipie_bindings/exceptions.rb
+++ b/lib/apipie_bindings/exceptions.rb
@@ -34,10 +34,11 @@ module ApipieBindings
   end
 
   class AuthenticatorError < StandardError
-    attr_reader :type, :original_error
+    attr_reader :type, :cause, :original_error
 
-    def initialize(type, original_error)
+    def initialize(type, cause, original_error)
       @type = type
+      @cause = cause
       @original_error = original_error
     end
   end

--- a/lib/apipie_bindings/exceptions.rb
+++ b/lib/apipie_bindings/exceptions.rb
@@ -33,4 +33,12 @@ module ApipieBindings
     end
   end
 
+  class AuthenticatorError < StandardError
+    attr_reader :type, :original_error
+
+    def initialize(type, original_error)
+      @type = type
+      @original_error = original_error
+    end
+  end
 end


### PR DESCRIPTION
Implements Negotiate authenticator.
This is bit Foreman way as it uses one specific url to authenticate against and expects other resources to be authenticated through session.